### PR TITLE
When constructing the path to the boot image, don't assume the NBI's are in a root level directory

### DIFF
--- a/bsdpserver.py
+++ b/bsdpserver.py
@@ -444,8 +444,6 @@ def getNbiOptions(incoming):
                     if nbimageinfo.get('RootPath'):
                         bootimage = find(nbimageinfo.get('RootPath'), path)[0]
                         if os.path.islink(bootimage):
-                            #thisnbi['dmg'] = \
-                            #    '/'.join(os.path.realpath(bootimage).split('/')[2:])    
                             relativepath = os.path.realpath(bootimage).split('/')
                             for i in tftprootpath.split('/'):
                                 relativepath.remove(i)
@@ -453,8 +451,6 @@ def getNbiOptions(incoming):
                             logging.debug('Image %s RootPath is a symlink, resolving...'
                                 % nbimageinfo['Name'])
                         else:
-                            #thisnbi['dmg'] = \
-                            #    '/'.join(bootimage.split('/')[2:])
                             relativepath = bootimage.split('/')
                             for i in tftprootpath.split('/'):
                                 relativepath.remove(i)
@@ -463,8 +459,6 @@ def getNbiOptions(incoming):
                         for dmgtype in ('dmg', 'sparseimage'):
                             bootimage = find('*.%s' % dmgtype, path)[0]
                             if os.path.islink(bootimage):
-                                #thisnbi['dmg'] = \
-                                #    '/'.join(os.path.realpath(bootimage).split('/')[2:])
                                 relativepath = os.path.realpath(bootimage).split('/')
                                 for i in tftprootpath.split('/'):
                                     relativepath.remove(i)
@@ -472,8 +466,6 @@ def getNbiOptions(incoming):
                                 logging.debug('Image %s RootPath is a symlink, resolving...'
                                     % nbimageinfo['Name'])
                             else:
-                                #thisnbi['dmg'] = \
-                                #    '/'.join(bootimage.split('/')[2:])
                                 relativepath = bootimage.split('/')
                                 for i in tftprootpath.split('/'):
                                     relativepath.remove(i)

--- a/bsdpserver.py
+++ b/bsdpserver.py
@@ -454,7 +454,7 @@ def getNbiOptions(incoming):
                             relativebootimage = bootimage.split('/')
                             for i in tftprootpath.split('/'):
                                 relativebootimage.remove(i)
-                            thisnbi['dmg'] = relativebootimage
+                            thisnbi['dmg'] = '/'.join(relativebootimage)
                     else:
                         for dmgtype in ('dmg', 'sparseimage'):
                             bootimage = find('*.%s' % dmgtype, path)[0]

--- a/bsdpserver.py
+++ b/bsdpserver.py
@@ -449,8 +449,12 @@ def getNbiOptions(incoming):
                             logging.debug('Image %s RootPath is a symlink, resolving...'
                                 % nbimageinfo['Name'])
                         else:
-                            thisnbi['dmg'] = \
-                                '/'.join(bootimage.split('/')[2:])
+                            #thisnbi['dmg'] = \
+                            #    '/'.join(bootimage.split('/')[2:])
+                            relativebootimage = bootimage.split('/')
+                            for i in tftprootpath.split('/'):
+                                relativebootimage.remove(i)
+                            thisnbi['dmg'] = relativebootimage
                     else:
                         for dmgtype in ('dmg', 'sparseimage'):
                             bootimage = find('*.%s' % dmgtype, path)[0]

--- a/bsdpserver.py
+++ b/bsdpserver.py
@@ -451,10 +451,10 @@ def getNbiOptions(incoming):
                         else:
                             #thisnbi['dmg'] = \
                             #    '/'.join(bootimage.split('/')[2:])
-                            relativebootimage = bootimage.split('/')
+                            relativepath = bootimage.split('/')
                             for i in tftprootpath.split('/'):
-                                relativebootimage.remove(i)
-                            thisnbi['dmg'] = '/'.join(relativebootimage)
+                                relativepath.remove(i)
+                            thisnbi['dmg'] = '/'.join(relativepath)
                     else:
                         for dmgtype in ('dmg', 'sparseimage'):
                             bootimage = find('*.%s' % dmgtype, path)[0]

--- a/bsdpserver.py
+++ b/bsdpserver.py
@@ -270,7 +270,7 @@ try:
 
         else:
             if 'http' in bootproto:
-                basedmgpath = 'http://' + serverip_str + tftprootpath + '/'
+                basedmgpath = 'http://' + serverip_str + '/'
                 nbiurl = basedmgpath
                 logging.debug('Using HTTP basedmgpath %s' % basedmgpath)
             if 'nfs' in bootproto:

--- a/bsdpserver.py
+++ b/bsdpserver.py
@@ -444,8 +444,12 @@ def getNbiOptions(incoming):
                     if nbimageinfo.get('RootPath'):
                         bootimage = find(nbimageinfo.get('RootPath'), path)[0]
                         if os.path.islink(bootimage):
-                            thisnbi['dmg'] = \
-                                '/'.join(os.path.realpath(bootimage).split('/')[2:])
+                            #thisnbi['dmg'] = \
+                            #    '/'.join(os.path.realpath(bootimage).split('/')[2:])    
+                            relativepath = os.path.realpath(bootimage).split('/')
+                            for i in tftprootpath.split('/'):
+                                relativepath.remove(i)
+                            thisnbi['dmg'] = '/'.join(relativepath)                  
                             logging.debug('Image %s RootPath is a symlink, resolving...'
                                 % nbimageinfo['Name'])
                         else:
@@ -459,13 +463,21 @@ def getNbiOptions(incoming):
                         for dmgtype in ('dmg', 'sparseimage'):
                             bootimage = find('*.%s' % dmgtype, path)[0]
                             if os.path.islink(bootimage):
-                                thisnbi['dmg'] = \
-                                    '/'.join(os.path.realpath(bootimage).split('/')[2:])
+                                #thisnbi['dmg'] = \
+                                #    '/'.join(os.path.realpath(bootimage).split('/')[2:])
+                                relativepath = os.path.realpath(bootimage).split('/')
+                                for i in tftprootpath.split('/'):
+                                    relativepath.remove(i)
+                                thisnbi['dmg'] = '/'.join(relativepath)
                                 logging.debug('Image %s RootPath is a symlink, resolving...'
                                     % nbimageinfo['Name'])
                             else:
-                                thisnbi['dmg'] = \
-                                    '/'.join(bootimage.split('/')[2:])
+                                #thisnbi['dmg'] = \
+                                #    '/'.join(bootimage.split('/')[2:])
+                                relativepath = bootimage.split('/')
+                                for i in tftprootpath.split('/'):
+                                    relativepath.remove(i)
+                                thisnbi['dmg'] = '/'.join(relativepath)
 
 
                 thisnbi['enabledmacaddrs'] = \


### PR DESCRIPTION
This patch constructs the relative path to the boot image by subtracting the tftprootpath from the full path.  Since tftprootpath is passed into bsdpy at runtime, it makes sense to use this instead of making any assumptions about directory depth.
